### PR TITLE
Improved performance and benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 bytes = "1.0.1"
 futures-util = { version = "0.3.8", default-features = false, features = ["std"] }
-tokio = { version = "1.4.0", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.5.0", features = ["macros", "net", "rt-multi-thread"] }
 tokio-util = { version = "0.6.5", features = ["codec", "net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
@@ -18,6 +18,7 @@ env_logger = "0.8.3"
 
 [dev-dependencies]
 criterion = "0.3.4"
+tokio = { version = "1.5.0", features = ["full"] }
 
 [[bench]]
 name = "filter_bench"
@@ -25,4 +26,8 @@ harness = false
 
 [[bench]]
 name = "codec_bench"
+harness = false
+
+[[bench]]
+name = "integration_bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,22 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
-thread-id = { version = "4" }
+bytes = "1.0.1"
+futures-util = { version = "0.3.8", default-features = false, features = ["std"] }
+tokio = { version = "1.4.0", features = ["macros", "net", "rt-multi-thread"] }
+tokio-util = { version = "0.6.5", features = ["codec", "net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-log = { version = "0.4" }
+log = "0.4"
 env_logger = "0.8.3"
+
+[dev-dependencies]
+criterion = "0.3.4"
+
+[[bench]]
+name = "filter_bench"
+harness = false
+
+[[bench]]
+name = "codec_bench"
+harness = false

--- a/benches/codec_bench.rs
+++ b/benches/codec_bench.rs
@@ -4,7 +4,7 @@ use statsd_filter_proxy_rs::filtered_codec::FilteredCodec;
 use tokio_util::codec::Decoder;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("Filter benchmark", |b| {
+    c.bench_function("Codec benchmark", |b| {
         b.iter_custom(|iters| {
             let block_list = black_box(vec![
                 String::from("foo"),
@@ -23,7 +23,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 block_list: block_list.into_iter().map(Bytes::from).collect(),
             };
 
-            let data = black_box(b"notfoo:1|c\nfoo:2|c\nnotfoo:3|c\n");
+            let data = black_box(b"notfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\n");
 
             let mut duration = std::time::Duration::from_secs(0);
 
@@ -43,7 +43,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
 fn filter_bench() {
     let mut c = Criterion::default()
-        .measurement_time(std::time::Duration::from_secs(60))
+        .measurement_time(std::time::Duration::from_secs(10))
         .sample_size(1000);
 
     criterion_benchmark(&mut c);

--- a/benches/codec_bench.rs
+++ b/benches/codec_bench.rs
@@ -1,0 +1,52 @@
+use bytes::{Bytes, BytesMut};
+use criterion::{black_box, criterion_main, Criterion};
+use statsd_filter_proxy_rs::filtered_codec::FilteredCodec;
+use tokio_util::codec::Decoder;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("Filter benchmark", |b| {
+        b.iter_custom(|iters| {
+            let block_list = black_box(vec![
+                String::from("foo"),
+                String::from("otherfoo"),
+                String::from("otherfoo2"),
+                String::from("otherfoo3"),
+                String::from("otherfoo4"),
+                String::from("otherfoo5"),
+                String::from("otherfoo6"),
+                String::from("otherfoo7"),
+                String::from("otherfoo8"),
+                String::from("otherfoo9"),
+            ]);
+
+            let mut filter = FilteredCodec {
+                block_list: block_list.into_iter().map(Bytes::from).collect(),
+            };
+
+            let data = black_box(b"notfoo:1|c\nfoo:2|c\nnotfoo:3|c\n");
+
+            let mut duration = std::time::Duration::from_secs(0);
+
+            for _ in 0..iters {
+                let mut src = BytesMut::from(&data[..]);
+                let now = std::time::Instant::now();
+
+                let _ = filter.decode(&mut src);
+
+                duration += now.elapsed();
+            }
+
+            duration
+        });
+    });
+}
+
+fn filter_bench() {
+    let mut c = Criterion::default()
+        .measurement_time(std::time::Duration::from_secs(60))
+        .sample_size(1000);
+
+    criterion_benchmark(&mut c);
+}
+
+criterion_main!(filter_bench);

--- a/benches/filter_bench.rs
+++ b/benches/filter_bench.rs
@@ -1,11 +1,11 @@
+use bytes::Bytes;
 use criterion::{black_box, criterion_main, Criterion};
-use statsd_filter_proxy_rs::filter::filter;
+use statsd_filter_proxy_rs::filter::{filter, filter_2};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Filter benchmark", |b| {
         b.iter_custom(|iters| {
             let block_list = black_box(vec![
-                String::from("foo"),
                 String::from("otherfoo"),
                 String::from("otherfoo2"),
                 String::from("otherfoo3"),
@@ -15,9 +15,10 @@ fn criterion_benchmark(c: &mut Criterion) {
                 String::from("otherfoo7"),
                 String::from("otherfoo8"),
                 String::from("otherfoo9"),
+                String::from("foo"),
             ]);
 
-            let data = black_box(b"notfoo:1|c\nfoo:2|c\nnotfoo:3|c");
+            let data = black_box(b"notfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\n");
 
             let now = std::time::Instant::now();
 
@@ -28,11 +29,40 @@ fn criterion_benchmark(c: &mut Criterion) {
             now.elapsed()
         });
     });
+
+    c.bench_function("Filter benchmark 2", |b| {
+        b.iter_custom(|iters| {
+            let block_list = black_box(vec![
+                String::from("otherfoo"),
+                String::from("otherfoo2"),
+                String::from("otherfoo3"),
+                String::from("otherfoo4"),
+                String::from("otherfoo5"),
+                String::from("otherfoo6"),
+                String::from("otherfoo7"),
+                String::from("otherfoo8"),
+                String::from("otherfoo9"),
+                String::from("foo"),
+            ]);
+
+            let block_list = block_list.into_iter().map(Bytes::from).collect::<Vec<_>>();
+
+            let data = black_box(b"notfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\nnotfoo:1|c\nfoo:2|c\nnotfoo:3|c\n");
+
+            let now = std::time::Instant::now();
+
+            for _ in 0..iters {
+                filter_2(&block_list, data);
+            }
+
+            now.elapsed()
+        });
+    });
 }
 
 fn filter_bench() {
     let mut c = Criterion::default()
-        .measurement_time(std::time::Duration::from_secs(60))
+        .measurement_time(std::time::Duration::from_secs(10))
         .sample_size(1000);
 
     criterion_benchmark(&mut c);

--- a/benches/filter_bench.rs
+++ b/benches/filter_bench.rs
@@ -1,0 +1,41 @@
+use criterion::{black_box, criterion_main, Criterion};
+use statsd_filter_proxy_rs::filter::filter;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("Filter benchmark", |b| {
+        b.iter_custom(|iters| {
+            let block_list = black_box(vec![
+                String::from("foo"),
+                String::from("otherfoo"),
+                String::from("otherfoo2"),
+                String::from("otherfoo3"),
+                String::from("otherfoo4"),
+                String::from("otherfoo5"),
+                String::from("otherfoo6"),
+                String::from("otherfoo7"),
+                String::from("otherfoo8"),
+                String::from("otherfoo9"),
+            ]);
+
+            let data = black_box(b"notfoo:1|c\nfoo:2|c\nnotfoo:3|c");
+
+            let now = std::time::Instant::now();
+
+            for _ in 0..iters {
+                filter(&block_list, data);
+            }
+
+            now.elapsed()
+        });
+    });
+}
+
+fn filter_bench() {
+    let mut c = Criterion::default()
+        .measurement_time(std::time::Duration::from_secs(60))
+        .sample_size(1000);
+
+    criterion_benchmark(&mut c);
+}
+
+criterion_main!(filter_bench);

--- a/benches/integration_bench.rs
+++ b/benches/integration_bench.rs
@@ -1,0 +1,169 @@
+use bytes::BytesMut;
+use statsd_filter_proxy_rs::{old_run_server, run_server, Config};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::net::UdpSocket;
+use tokio::sync::Notify;
+use tokio::time::{self, error::Elapsed};
+
+#[tokio::main]
+async fn main() {
+    let msg_count = 1_000;
+    let threads = 4;
+
+    let config = Config {
+        listen_host: String::from("127.0.0.1"),
+        listen_port: 8125,
+        target_host: String::from("127.0.0.1"),
+        target_port: 8126,
+        metric_blocklist: vec![
+            String::from("foo"),
+            String::from("otherfoo"),
+            String::from("otherfoo2"),
+            String::from("otherfoo3"),
+            String::from("otherfoo4"),
+            String::from("otherfoo5"),
+            String::from("otherfoo6"),
+            String::from("otherfoo7"),
+            String::from("otherfoo8"),
+            String::from("otherfoo9"),
+        ],
+        multi_thread: None,
+    };
+
+    let stop = Arc::new(Notify::new());
+
+    tokio::spawn(spawn_old(config.clone(), false, stop.clone()));
+
+    let mut received = 0;
+    match run(msg_count, threads, &mut received).await {
+        Ok(duration) => {
+            println!(
+                "[Filter classic] Processed {} messages in {:?} | {:?}/msg",
+                received,
+                duration,
+                duration / received as u32
+            );
+        }
+        Err(_) => {
+            println!(
+                "[Filter classic] Test timed out after 60s and {} messages",
+                received
+            );
+        }
+    }
+
+    stop.notify_waiters();
+
+    // Cooldown for cleanup
+    time::sleep(Duration::from_secs(10)).await;
+
+    let stop = Arc::new(Notify::new());
+
+    tokio::spawn(spawn_old(config.clone(), true, stop.clone()));
+
+    let mut received = 0;
+    match run(msg_count, threads, &mut received).await {
+        Ok(duration) => {
+            println!(
+                "[Filter 2] Processed {} messages in {:?} | {:?}/msg",
+                received,
+                duration,
+                duration / received as u32
+            );
+        }
+        Err(_) => {
+            println!(
+                "[Filter 2] Test timed out after 60s and {} messages",
+                received
+            );
+        }
+    }
+
+    stop.notify_waiters();
+
+    // Cooldown for cleanup
+    time::sleep(Duration::from_secs(10)).await;
+
+    let stop = Arc::new(Notify::new());
+
+    tokio::spawn(spawn_new(config, stop.clone()));
+
+    let mut received = 0;
+    match run(msg_count, threads, &mut received).await {
+        Ok(duration) => {
+            println!(
+                "[Codec] Processed {} messages in {:?} | {:?}/msg",
+                received,
+                duration,
+                duration / received as u32
+            );
+        }
+        Err(_) => {
+            println!("[Codec] Test timed out after 60s and {} messages", received);
+        }
+    }
+
+    stop.notify_waiters();
+
+    // Cooldown for cleanup
+    time::sleep(Duration::from_secs(10)).await;
+}
+
+async fn spawn_new(config: Config, stop: Arc<Notify>) {
+    tokio::select! {
+        _ = run_server(config) => {}
+        _ = stop.notified() => {}
+    }
+}
+
+async fn spawn_old(config: Config, use_fn_2: bool, stop: Arc<Notify>) {
+    tokio::select! {
+        _ = old_run_server(config, use_fn_2) => {}
+        _ = stop.notified() => {}
+    }
+}
+
+async fn run(msg_count: usize, threads: usize, received: &mut usize) -> Result<Duration, Elapsed> {
+    let notify = Arc::new(Notify::new());
+
+    for i in 0..threads {
+        let notify = notify.clone();
+        let addr = format!("127.0.0.1:1000{}", i);
+        let sock = UdpSocket::bind(addr).await.unwrap();
+        sock.connect("127.0.0.1:8125").await.unwrap();
+
+        tokio::spawn(async move {
+            notify.notified().await;
+
+            for i in 0..msg_count {
+                let _ = sock.send(format!("metric:{}|c\n", i).as_bytes()).await;
+            }
+        });
+    }
+
+    let expected = msg_count * threads;
+
+    time::timeout(Duration::from_secs(10), receive(notify, expected, received)).await
+}
+
+async fn receive(notify: Arc<Notify>, expected: usize, received: &mut usize) -> Duration {
+    let sock = UdpSocket::bind("127.0.0.1:8126").await.unwrap();
+    let mut buffer = BytesMut::with_capacity(10_000_000);
+
+    let start = Instant::now();
+
+    notify.notify_waiters();
+
+    while let Ok((_, _)) = sock.recv_from(&mut buffer).await {
+        *received += buffer[..].split(|x| x == &b'\n').count();
+
+        buffer.clear();
+
+        if *received >= expected {
+            break;
+        }
+    }
+
+    start.elapsed()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
     pub listen_host: String,
     pub listen_port: u16,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -13,7 +13,7 @@ pub fn filter(block_list: &Vec<String>, buf: &[u8]) -> String {
     });
 
     let result = result_itr.collect::<Vec<&str>>().join("\n");
-    
+
     return result;
 }
 
@@ -28,7 +28,6 @@ mod tests {
         let result = filter(&block_list, &statsd_str_bytes);
         assert_eq!("foo:1|c\nfoo:2|c\nfoo:3|c", result);
     }
-
 
     #[test]
     fn test_should_not_block_single_metric() {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,3 +1,4 @@
+use bytes::{BufMut, Bytes, BytesMut};
 use std::str;
 
 pub fn filter(block_list: &Vec<String>, buf: &[u8]) -> String {
@@ -15,6 +16,22 @@ pub fn filter(block_list: &Vec<String>, buf: &[u8]) -> String {
     let result = result_itr.collect::<Vec<&str>>().join("\n");
 
     return result;
+}
+
+pub fn filter_2(block_list: &[Bytes], data: &[u8]) -> Bytes {
+    let mut buffer = BytesMut::with_capacity(data.len());
+
+    'outer: for line in data.split(|x| x == &b'\n') {
+        for prefix in block_list {
+            if line.starts_with(prefix) {
+                continue 'outer;
+            }
+        }
+
+        buffer.put(line);
+    }
+
+    buffer.freeze()
 }
 
 #[cfg(test)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -29,6 +29,7 @@ pub fn filter_2(block_list: &[Bytes], data: &[u8]) -> Bytes {
         }
 
         buffer.put(line);
+        buffer.put_u8(b'\n');
     }
 
     buffer.freeze()
@@ -44,6 +45,10 @@ mod tests {
         let statsd_str_bytes = "foo:1|c\nfoo:2|c\nfoo:3|c".as_bytes();
         let result = filter(&block_list, &statsd_str_bytes);
         assert_eq!("foo:1|c\nfoo:2|c\nfoo:3|c", result);
+
+        let block_list = block_list.into_iter().map(Bytes::from).collect::<Vec<_>>();
+        let result = filter_2(&block_list, &statsd_str_bytes);
+        assert_eq!("foo:1|c\nfoo:2|c\nfoo:3|c\n", result);
     }
 
     #[test]
@@ -52,6 +57,10 @@ mod tests {
         let statsd_str_bytes = "foo:1|c".as_bytes();
         let result = filter(&block_list, &statsd_str_bytes);
         assert_eq!("foo:1|c", result);
+
+        let block_list = block_list.into_iter().map(Bytes::from).collect::<Vec<_>>();
+        let result = filter_2(&block_list, &statsd_str_bytes);
+        assert_eq!("foo:1|c\n", result);
     }
 
     #[test]
@@ -59,6 +68,10 @@ mod tests {
         let block_list = vec![String::from("foo"), String::from("otherfoo")];
         let statsd_str_bytes = "foo:1|c".as_bytes();
         let result = filter(&block_list, &statsd_str_bytes);
+        assert_eq!("", result);
+
+        let block_list = block_list.into_iter().map(Bytes::from).collect::<Vec<_>>();
+        let result = filter_2(&block_list, &statsd_str_bytes);
         assert_eq!("", result);
     }
 
@@ -68,6 +81,10 @@ mod tests {
         let statsd_str_bytes = "foo:1|c\nfoo:2|c\nfoo:3|c".as_bytes();
         let result = filter(&block_list, &statsd_str_bytes);
         assert_eq!("", result);
+
+        let block_list = block_list.into_iter().map(Bytes::from).collect::<Vec<_>>();
+        let result = filter_2(&block_list, &statsd_str_bytes);
+        assert_eq!("", result);
     }
 
     #[test]
@@ -76,5 +93,9 @@ mod tests {
         let statsd_str_bytes = "notfoo:1|c\nfoo:2|c\nnotfoo:3|c".as_bytes();
         let result = filter(&block_list, &statsd_str_bytes);
         assert_eq!("notfoo:1|c\nnotfoo:3|c", result);
+
+        let block_list = block_list.into_iter().map(Bytes::from).collect::<Vec<_>>();
+        let result = filter_2(&block_list, &statsd_str_bytes);
+        assert_eq!("notfoo:1|c\nnotfoo:3|c\n", result);
     }
 }

--- a/src/filtered_codec.rs
+++ b/src/filtered_codec.rs
@@ -1,0 +1,111 @@
+use bytes::{BufMut, Bytes, BytesMut};
+use std::collections::BTreeSet;
+use tokio_util::codec::Decoder;
+
+pub struct FilteredCodec {
+    pub block_list: BTreeSet<Bytes>,
+}
+
+impl Decoder for FilteredCodec {
+    type Item = BytesMut;
+    type Error = std::io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let mut buffer = BytesMut::new();
+
+        while let Some(datagram) = get_datagram(src) {
+            let tag = match datagram.iter().position(|x| x == &b':') {
+                Some(pos) => &datagram[..pos],
+                None => &datagram[..],
+            };
+
+            if self.block_list.contains(tag) {
+                continue;
+            }
+
+            buffer.put(datagram);
+        }
+
+        Ok(if buffer.is_empty() {
+            None
+        } else {
+            Some(buffer)
+        })
+    }
+}
+
+fn get_datagram(src: &mut BytesMut) -> Option<BytesMut> {
+    src.iter()
+        .position(|c| c == &b'\n')
+        .map(|pos| src.split_to(pos + 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_not_block_multi_metric() {
+        let block_list = vec![String::from("notfoo"), String::from("otherfoo")];
+        let mut filter = FilteredCodec {
+            block_list: block_list.into_iter().map(Bytes::from).collect(),
+        };
+
+        let statsd_str_bytes = "foo:1|c\nfoo:2|c\nfoo:3|c\n".as_bytes();
+        let result = filter.decode(&mut BytesMut::from(statsd_str_bytes));
+        let result = result.unwrap().unwrap();
+        assert_eq!(&statsd_str_bytes[..], result);
+    }
+
+    #[test]
+    fn test_should_not_block_single_metric() {
+        let block_list = vec![String::from("notfoo"), String::from("otherfoo")];
+        let mut filter = FilteredCodec {
+            block_list: block_list.into_iter().map(Bytes::from).collect(),
+        };
+
+        let statsd_str_bytes = "foo:1|c\n".as_bytes();
+        let result = filter.decode(&mut BytesMut::from(statsd_str_bytes));
+        let result = result.unwrap().unwrap();
+        assert_eq!(&statsd_str_bytes[..], result);
+    }
+
+    #[test]
+    fn test_should_block_completely_single_metric() {
+        let block_list = vec![String::from("foo"), String::from("otherfoo")];
+        let mut filter = FilteredCodec {
+            block_list: block_list.into_iter().map(Bytes::from).collect(),
+        };
+
+        let statsd_str_bytes = "foo:1|c\n".as_bytes();
+        let result = filter.decode(&mut BytesMut::from(statsd_str_bytes));
+        let result = result.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_should_block_completely_multi_metric() {
+        let block_list = vec![String::from("foo"), String::from("otherfoo")];
+        let mut filter = FilteredCodec {
+            block_list: block_list.into_iter().map(Bytes::from).collect(),
+        };
+
+        let statsd_str_bytes = "foo:1|c\nfoo:2|c\nfoo:3|c\n".as_bytes();
+        let result = filter.decode(&mut BytesMut::from(statsd_str_bytes));
+        let result = result.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_should_block_partially_multi_metric() {
+        let block_list = vec![String::from("foo"), String::from("otherfoo")];
+        let mut filter = FilteredCodec {
+            block_list: block_list.into_iter().map(Bytes::from).collect(),
+        };
+
+        let statsd_str_bytes = "notfoo:1|c\nfoo:2|c\nnotfoo:3|c\n".as_bytes();
+        let result = filter.decode(&mut BytesMut::from(statsd_str_bytes));
+        let result = result.unwrap().unwrap();
+        assert_eq!("notfoo:1|c\nnotfoo:3|c\n".as_bytes(), result);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,58 @@
+mod config;
 pub mod filter;
 pub mod filtered_codec;
+mod server;
+
+pub use self::config::Config;
+pub use self::server::run_server;
+use bytes::Bytes;
+use log::{debug, info};
+use std::net::SocketAddr;
+use tokio::net::UdpSocket;
+
+pub async fn old_run_server(config: Config, use_fn_2: bool) -> std::io::Result<()> {
+    let addr = format!("{}:{}", config.listen_host, config.listen_port);
+    let sock = UdpSocket::bind(addr).await?;
+
+    let block_list = config.metric_blocklist;
+    let block_list_2 = block_list
+        .iter()
+        .cloned()
+        .map(Bytes::from)
+        .collect::<Vec<_>>();
+
+    info!("Listening on: {}", sock.local_addr()?);
+
+    let mut buf = [0; 8192];
+
+    let target_addr: SocketAddr = format!("{}:{}", config.target_host, config.target_port)
+        .parse()
+        .expect("Unable to parse socket address");
+
+    loop {
+        let (len, addr) = sock.recv_from(&mut buf).await?;
+        debug!("{:?} bytes received from {:?} onto {:p}", len, addr, &buf);
+
+        let len = if use_fn_2 {
+            let filtered = crate::filter::filter_2(&block_list_2, &buf);
+
+            if filtered.is_empty() {
+                continue;
+            }
+
+            sock.send_to(&filtered[..], &target_addr).await.unwrap()
+        } else {
+            let filtered = crate::filter::filter(&block_list, &buf);
+
+            if filtered.is_empty() {
+                continue;
+            }
+
+            sock.send_to(filtered.as_bytes(), &target_addr)
+                .await
+                .unwrap()
+        };
+
+        debug!("Echoed {} bytes to {}", len, target_addr);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod filter;
+pub mod filtered_codec;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 mod config;
-mod filter;
+mod filtered_codec;
 mod server;
 
 use std::env;
@@ -8,12 +8,12 @@ use std::path::Path;
 #[tokio::main]
 async fn main() {
     env_logger::init();
-    let config_path_env = env::var("PROXY_CONFIG_FILE")
-        .expect("PROXY_CONFIG_FILE must be set");
+    let config_path_env = env::var("PROXY_CONFIG_FILE").expect("PROXY_CONFIG_FILE must be set");
 
     let path = Path::new(&config_path_env);
-    let _config = config::parse(&path);
-    server::run_server(_config)
+    let config = config::parse(&path);
+
+    server::run_server(config)
         .await
         .expect("Unable to run server");
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,78 +1,54 @@
-use std::net::SocketAddr;
-use std::{io, sync::Arc};
-use tokio::net::UdpSocket;
-
 use crate::config::Config;
-use crate::filter::filter;
+use crate::filtered_codec::FilteredCodec;
+use bytes::Bytes;
+use futures_util::StreamExt;
+use log::{debug, info, warn};
+use std::net::SocketAddr;
+use tokio::net::UdpSocket;
+use tokio_util::udp::UdpFramed;
 
-use log::{debug, info, log_enabled, trace, Level};
+pub async fn run_server(config: Config) -> std::io::Result<()> {
+    let addr = format!("{}:{}", config.listen_host, config.listen_port);
+    let sock = UdpSocket::bind(addr).await?;
 
-pub async fn run_server(config: Config) -> io::Result<()> {
-    let sock = UdpSocket::bind(format!("{}:{}", config.listen_host, config.listen_port)).await?;
     info!("Listening on: {}", sock.local_addr()?);
-
-    let sock = Arc::new(sock);
-    let blocklist = Arc::new(config.metric_blocklist);
-
-    let mut buf = [0; 8192];
-    let multi_thread = config.multi_thread.unwrap_or(false);
-
-    if multi_thread {
-        trace!("multi_thread is enabled");
-    }
 
     let target_addr: SocketAddr = format!("{}:{}", config.target_host, config.target_port)
         .parse()
         .expect("Unable to parse socket address");
 
-    let target_addr = Arc::new(target_addr);
+    let codec = FilteredCodec {
+        block_list: config
+            .metric_blocklist
+            .into_iter()
+            .map(Bytes::from)
+            .collect(),
+    };
 
-    loop {
-        let (len, addr) = sock.recv_from(&mut buf).await?;
-        debug!("{:?} bytes received from {:?} onto {:p}", len, addr, &buf);
+    let mut framed = UdpFramed::new(sock, codec);
 
-        if log_enabled!(Level::Trace) {
-            trace!(
-                "{:?} at {:p}",
-                std::str::from_utf8(&buf[..len]).unwrap(),
-                &buf
-            );
-        }
-
-        if multi_thread {
-            let sock_clone = sock.clone();
-            let target_addr_clone = target_addr.clone();
-            let blocklist_clone = blocklist.clone();
-            tokio::spawn(async move {
-                let filtered_string = filter(&blocklist_clone, &buf[..len]);
-                if filtered_string.len() > 0 {
-                    let len = sock_clone
-                        .send_to(filtered_string.as_bytes(), &*target_addr_clone)
-                        .await
-                        .unwrap();
-
-                    debug!(
-                        "Thread {}, Echoed {} bytes to {}",
-                        thread_id::get(),
-                        len,
-                        target_addr_clone
-                    );
-                }
-            });
-        } else {
-            let filtered_string = filter(&blocklist, &buf[..len]);
-            if filtered_string.len() > 0 {
-                let len = sock
-                    .send_to(filtered_string.as_bytes(), &*target_addr)
-                    .await
-                    .unwrap();
+    while let Some(frame) = framed.next().await {
+        let frame = match frame {
+            Ok((frame, addr)) => {
                 debug!(
-                    "Thread {}, Echoed {} bytes to {}",
-                    thread_id::get(),
-                    len,
-                    target_addr
+                    "Received frame {:?} from {:?}",
+                    std::str::from_utf8(&frame),
+                    addr
                 );
+
+                frame
             }
+            Err(e) => {
+                warn!("Failed to parse frame: {:?}", e);
+
+                continue;
+            }
+        };
+
+        if let Err(e) = framed.get_ref().send_to(&frame, &target_addr).await {
+            warn!("Couldn't send metric to metrics server: {:?}", e);
         }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Current implementation has a a few downsides:
- It uses an unsafe block to skip the utf-8 validation of bytes. Although a reasonable thing to do, it's avoidable
- Uses full features of dependencies. This is a minor thing, but causes longer compile times and larger resulting binary
- Filtering causes allocations. As the filter deals with data as strings and returns a `String`, this requires allocations that could be avoided.
- Is limited to buffers of 8kb. This also causes a constraint on the max size of the datagrams
- Inappropriate benchmark. It depends on a Python script that could produce data slower than what the Rust application can really handle, yielding inaccurate results.
- Naive multi-threading that causes more overhead than potential benefit. Other forms of multi-threading would be better fitted than the proposed one, however the filtering algorithm can be considerably improved rendering the need for multi-threading unnecessary

Although not all of the downsides were addressed and further improvements are possible, this MR proposes the following improvements:
- Use pure bytes comparison so no utf-8 validation/conversion is ever required and removes the unsafe block. This also removes the need for allocation when (unnecessarily) converting to `String`
- Switch from `full` to limited features in the Tokio dependency to improve compile times and binary size
- Use `tokio_util` to build a codec and use `UdpFramed` to make code more ergonomic
- Build a codec that process the `BytesMut` buffer (provided by `tokio_util`) to drop the unwanted byte slices and concatenate the desired ones.
- By using the codec approach from `tokio_util`, a `BytesMut` buffer that can automatically grow if needed is provided "for free" (as in: no need to manually manage buffers)
- Include micro-benchmarking of the filtering implementations with Criterion to reliably compare their speeds. Spoiler: the new implementation is almost 3 times faster (~182 ns/iter vs ~465 ns/iter)
- Use a `BTreeSet<Bytes>` instead of a `Vec<String>` for faster comparisons. This comes at the expense of only working for exact matches, but could be changed to use [regex](https://github.com/rust-lang/regex#usage-match-regular-expressions-on-u8)